### PR TITLE
Remove unnecessary `fs` dependency

### DIFF
--- a/Spotify/package.json
+++ b/Spotify/package.json
@@ -14,7 +14,6 @@
   "license": "MIT",
   "dependencies": {
     "discord.js": "^11.1.0",
-    "fs": "0.0.1-security",
     "performance-now": "^2.1.0",
     "youtube-node": "^1.3.0",
     "ytdl-core": "^0.14.4"


### PR DESCRIPTION
`fs` is a built-in node module, so you can't install it from npm.